### PR TITLE
Improve mobile dashboard and logging experience

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,18 @@
   
   <script type="module">
     // Import all necessary functions from the new db.js module
-    import { getPractices, addPractice as dbAddPractice, deletePractice as dbDeletePractice, getProfile, setProfile, clearAllData } from './db.js';
+    import {
+      getPractices,
+      addPractice as dbAddPractice,
+      deletePractice as dbDeletePractice,
+      getProfile,
+      setProfile,
+      clearAllData,
+      ALL_BADGES,
+      checkBadges as dbCheckBadges,
+      PHASES,
+      getPhase as dbGetPhase
+    } from './db.js';
     
     document.addEventListener('DOMContentLoaded', () => {
       const root = document.getElementById('root');
@@ -38,70 +49,22 @@
       let currentTab = 'dashboard';
 
       // --- JOURNEY DATA & LOGIC ---
-      const PHASES = [
-        { id: 1, name: "The Baseline", goal: 10, description: "Focus on fundamental movement and conditioning. Log 10 practices to establish consistency." },
-        { id: 2, name: "The Grind", goal: 50, description: "Refining core techniques and finding your preferred style. Log 50 total practices." },
-        { id: 3, name: "The Competitor", goal: 100, description: "Peak conditioning, advanced technique chains, and mental preparation. Log 100 total practices." },
-        // ... extend as needed
-      ];
-
-      function getPhase(totalPractices) {
-          let currentPhase = PHASES[0];
-          let nextPhase = null;
-
-          for (let i = 0; i < PHASES.length; i++) {
-              if (totalPractices >= PHASES[i].goal) {
-                  currentPhase = PHASES[i];
-                  if (PHASES[i+1]) {
-                      nextPhase = PHASES[i+1];
-                  }
-              } else if (totalPractices < PHASES[i].goal && !nextPhase) {
-                  nextPhase = PHASES[i];
-              }
-          }
-          const progress = nextPhase ? Math.min(100, (totalPractices / nextPhase.goal) * 100) : 100;
-
-          return { current: currentPhase, next: nextPhase, progress };
-      }
-
-      const ALL_BADGES = [
-          { id: 1, name: 'First Practice', icon: '🏆', check: (p) => p.length >= 1 },
-          { id: 2, name: '10 Practices', icon: '🎖️', check: (p) => p.length >= 10 },
-          { id: 3, name: '50 Practices', icon: '🥇', check: (p) => p.length >= 50 },
-          { id: 4, name: '4+ Rating', icon: '⭐', check: (p) => p.length && (p.reduce((sum, pr) => sum + (pr.intensity || 0), 0) / p.length) >= 4 },
-      ];
-
-      function checkBadges(practices, currentProfile) {
-          let updatedProfile = { ...currentProfile };
-          let changed = false;
-
-          const latestPracticeNum = practices.length;
-
-          ALL_BADGES.forEach(badge => {
-              const isEarned = currentProfile.earnedBadges.some(b => b.id === badge.id);
-              
-              if (!isEarned && badge.check(practices)) {
-                  updatedProfile.earnedBadges.push({
-                      id: badge.id,
-                      earnedDate: new Date().toISOString(),
-                      practiceNumber: latestPracticeNum
-                  });
-                  changed = true;
-                  console.log(`Badge Earned: ${badge.name}`);
-              }
-          });
-          return changed ? updatedProfile : null;
-      }
+      const BADGE_ICONS = {
+        1: '🏆',
+        2: '🎖️',
+        3: '🥇',
+        4: '⭐'
+      };
       
       // --- RENDER FUNCTION ---
       async function render() {
         practices = await getPractices();
         profile = await getProfile();
 
-        const { current: currentPhase, next: nextPhase, progress } = getPhase(practices.length);
-        
+        const { current: currentPhase, next: nextPhase } = dbGetPhase(practices.length);
+
         // Update profile if a badge was earned
-        const updatedProfile = checkBadges(practices, profile);
+        const updatedProfile = dbCheckBadges(practices, profile);
         if (updatedProfile) {
             profile = updatedProfile;
             await setProfile(profile);
@@ -114,158 +77,293 @@
           lastPracticeDate: practices.length ? new Date(practices.slice(-1)[0].date).toLocaleDateString() : 'N/A'
         };
 
+        const earnedBadges = (profile.earnedBadges || []).sort((a, b) => new Date(a.earnedDate) - new Date(b.earnedDate));
+        const latestBadges = earnedBadges.slice(-3).reverse();
+        const nextGoal = nextPhase ? nextPhase.goal : currentPhase.goal;
+        const progressPercent = Math.min(100, Math.max(0, Math.round((practices.length / nextGoal) * 100)));
+        const sessionsRemaining = Math.max(0, nextGoal - practices.length);
+        const sessionsLabel = sessionsRemaining === 1 ? 'session' : 'sessions';
+        const totalHours = (stats.totalTime / 60).toFixed(1);
+        const lastPractice = practices.length ? practices[practices.length - 1] : null;
+
         root.innerHTML = `
           <div class="app">
-            <h1 class="title">Wrestling Journey</h1>
-            
-            <!-- Tab Buttons - Aligned with Truth Doc -->
-            <div class="tabs">
-              <button id="tab-dashboard" class="tab ${currentTab === 'dashboard' ? 'active' : ''}">Dashboard</button>
-              <button id="tab-log" class="tab ${currentTab === 'log' ? 'active' : ''}">Log Practice</button>
-              <button id="tab-history" class="tab ${currentTab === 'history' ? 'active' : ''}">History</button>
-              <button id="tab-badges" class="tab ${currentTab === 'badges' ? 'active' : ''}">Badges</button>
-              <button id="tab-guide" class="tab ${currentTab === 'guide' ? 'active' : ''}">Journey Guide</button>
-              <button id="tab-settings" class="tab ${currentTab === 'settings' ? 'active' : ''}">Settings</button>
-            </div>
-            
-            <!-- Dashboard Section -->
-            <div id="section-dashboard" class="section ${currentTab === 'dashboard' ? 'active' : ''}">
-              <h2>Your Journey: ${currentPhase.name}</h2>
-              <p>Next Goal: ${nextPhase ? `${nextPhase.goal} Practices (${nextPhase.name})` : 'Mastery!'}</p>
-              
-              <div class="progress-bar-container">
-                  <div class="progress-bar" style="width: ${progress}%"></div>
+            <header class="hero">
+              <div class="hero-copy">
+                <p class="hero-tag">Pixel 8 ready · Offline · Dark mode only</p>
+                <h1 class="title">Wrestling Journey</h1>
+                <p class="hero-subtitle">Track the grind honestly. Wrestling takes years, consistency wins.</p>
               </div>
-              <p class="progress-label">${practices.length} / ${nextPhase ? nextPhase.goal : practices.length} Practices</p>
+              <button class="button secondary hero-action" id="hero-log-btn">Log today</button>
+            </header>
 
-              <div class="stats">
-                <div class="stat-card"><h3>Total Practices</h3><p>${stats.totalPractices}</p></div>
-                <div class="stat-card"><h3>Avg Intensity</h3><p>⭐ ${stats.avgIntensity}/10</p></div>
-                <div class="stat-card"><h3>Total Time</h3><p>${stats.totalTime} min</p></div>
-              </div>
-            </div>
+            <nav class="tabs" role="tablist">
+              <button id="tab-dashboard" class="tab ${currentTab === 'dashboard' ? 'active' : ''}" role="tab">Dashboard</button>
+              <button id="tab-log" class="tab ${currentTab === 'log' ? 'active' : ''}" role="tab">Log</button>
+              <button id="tab-history" class="tab ${currentTab === 'history' ? 'active' : ''}" role="tab">History</button>
+              <button id="tab-badges" class="tab ${currentTab === 'badges' ? 'active' : ''}" role="tab">Badges</button>
+              <button id="tab-guide" class="tab ${currentTab === 'guide' ? 'active' : ''}" role="tab">Guide</button>
+              <button id="tab-settings" class="tab ${currentTab === 'settings' ? 'active' : ''}" role="tab">Settings</button>
+            </nav>
 
-            <!-- Log Practice Section - Structured Input -->
-            <div id="section-log" class="section ${currentTab === 'log' ? 'active' : ''}">
-              <h2>Log a Practice</h2>
-              <form id="practice-form" class="input-group">
-                
-                <div class="form-row form-row-full">
-                  <label for="practice-type">Type:</label>
-                  <select id="practice-type" class="input">
-                      <option value="drills">Drills/Technique</option>
-                      <option value="live">Live Sparring/Rolling</option>
-                      <option value="conditioning">Conditioning/Strength</option>
-                      <option value="competition">Competition</option>
-                  </select>
-                </div>
-                
-                <div class="form-row form-row-full">
-                  <label for="practice-date">Date:</label>
-                  <input id="practice-date" type="date" class="input" value="${new Date().toISOString().split('T')[0]}">
-                </div>
-
-                <div class="form-row form-row-full duration-presets">
-                    <label>Duration Presets (min):</label>
+            <main class="panels">
+              <!-- Dashboard -->
+              <section id="section-dashboard" class="section ${currentTab === 'dashboard' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
                     <div>
-                        <button type="button" class="button preset-btn" data-duration="60">60</button>
-                        <button type="button" class="button preset-btn" data-duration="90">90</button>
-                        <button type="button" class="button preset-btn" data-duration="120">120</button>
+                      <p class="eyebrow">Current Phase</p>
+                      <h2>${currentPhase.name}</h2>
                     </div>
-                </div>
+                    <span class="phase-chip">${stats.totalPractices} logged</span>
+                  </div>
+                  <p class="panel-subtitle">Next milestone: ${nextPhase ? `${nextPhase.goal} practices · ${nextPhase.name}` : 'Mastery — keep sharpening your edge.'}</p>
+                  <div class="progress-summary">
+                    <div class="progress-ring" style="--progress:${progressPercent}%">
+                      <span>${progressPercent}%</span>
+                    </div>
+                    <div class="progress-details">
+                      <p class="progress-count">${practices.length} / ${nextGoal} practices logged</p>
+                      <p class="progress-note">${sessionsRemaining > 0 ? `${sessionsRemaining} more ${sessionsLabel} until ${nextPhase ? nextPhase.name : currentPhase.name}.` : 'You hit this milestone. Stay humble and keep the reps coming.'}</p>
+                      <p class="progress-last">${lastPractice ? `Last logged: ${new Date(lastPractice.date).toLocaleDateString()} · ${lastPractice.type}` : 'You have not logged a practice yet. Start today—no fluff, just work.'}</p>
+                    </div>
+                  </div>
+                  <div class="dashboard-actions">
+                    <button class="button" data-switch-to="log">Add practice</button>
+                    <button class="button ghost" data-switch-to="history">View history</button>
+                  </div>
+                </article>
 
-                <div class="form-row form-row-full">
-                  <label for="practice-duration">Manual Duration (min):</label>
-                  <input id="practice-duration" type="number" min="1" class="input small" placeholder="e.g. 75">
-                </div>
+                <article class="panel">
+                  <div class="panel-header">
+                    <h3>Consistency stats</h3>
+                  </div>
+                  <div class="stats-grid">
+                    <div class="stat-card">
+                      <p class="stat-label">Practices</p>
+                      <p class="stat-value">${stats.totalPractices}</p>
+                    </div>
+                    <div class="stat-card">
+                      <p class="stat-label">Hours logged</p>
+                      <p class="stat-value">${isNaN(totalHours) ? '0.0' : totalHours}</p>
+                    </div>
+                    <div class="stat-card">
+                      <p class="stat-label">Avg intensity</p>
+                      <p class="stat-value">${stats.avgIntensity}</p>
+                    </div>
+                    <div class="stat-card">
+                      <p class="stat-label">Last entry</p>
+                      <p class="stat-value">${stats.lastPracticeDate}</p>
+                    </div>
+                  </div>
+                </article>
 
-                <div class="form-row form-row-slider">
-                  <label for="practice-intensity">Intensity (1-10):</label>
-                  <input id="practice-intensity" type="range" min="1" max="10" value="5" class="input range">
-                  <span id="intensity-value">5</span>
-                </div>
+                <article class="panel">
+                  <div class="panel-header">
+                    <div>
+                      <h3>Badge shelf</h3>
+                      <p class="panel-subtitle">Badges celebrate volume, consistency, and honest notes.</p>
+                    </div>
+                    <button class="button-link" data-switch-to="badges">See all</button>
+                  </div>
+                  <div class="badge-shelf">
+                    ${latestBadges.length ? latestBadges.map(badge => {
+                      const badgeInfo = ALL_BADGES.find(item => item.id === badge.id);
+                      return `
+                        <div class="badge-token">
+                          <span class="badge-icon">${BADGE_ICONS[badge.id] || '🥋'}</span>
+                          <div class="badge-copy">
+                            <p class="badge-name">${badgeInfo ? badgeInfo.name : 'Badge'}</p>
+                            <p class="badge-meta">Practice #${badge.practiceNumber} · ${new Date(badge.earnedDate).toLocaleDateString()}</p>
+                          </div>
+                        </div>
+                      `;
+                    }).join('') : '<p class="empty">Log consistently to earn your first badge.</p>'}
+                  </div>
+                </article>
+              </section>
 
-                <div class="form-row form-row-slider">
-                  <label for="practice-physical">Physical Feel (1-5):</label>
-                  <input id="practice-physical" type="range" min="1" max="5" value="3" class="input range">
-                  <span id="physical-value">3</span>
-                </div>
-
-                <div class="form-row form-row-slider">
-                  <label for="practice-mental">Mental Feel (1-5):</label>
-                  <input id="practice-mental" type="range" min="1" max="5" value="3" class="input range">
-                  <span id="mental-value">3</span>
-                </div>
-                
-                <textarea id="practice-notes" placeholder="Notes: Key techniques learned, specific opponents, areas for improvement..." class="input textarea" rows="4"></textarea>
-
-                <button type="submit" class="button form-row-full">Log Practice</button>
-              </form>
-            </div>
-            
-            <!-- Practice History Section -->
-            <div id="section-history" class="section ${currentTab === 'history' ? 'active' : ''}">
-              <h2>Practice History (${practices.length} total)</h2>
-              <ul id="practice-list" class="practice-list">
-                ${practices.slice().reverse().map(p => `
-                  <li data-id="${p.id}">
-                    <div class="practice-content">
-                      <span class="practice-item-text">${p.notes}</span>
-                      <div class="practice-meta">
-                        <span class="practice-item-type">${p.type}</span>
-                        ${p.duration ? `<span class="practice-item-duration">${p.duration} min</span>` : ''}
-                        ${p.intensity ? `<span class="practice-item-intensity">I: ${p.intensity}/10</span>` : ''}
-                        <span class="practice-item-date">${new Date(p.date).toLocaleDateString()}</span>
+              <!-- Log Practice -->
+              <section id="section-log" class="section ${currentTab === 'log' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
+                    <div>
+                      <h2>Log today\'s work</h2>
+                      <p class="panel-subtitle">It should take under a minute. Be honest—progress is earned slowly.</p>
+                    </div>
+                  </div>
+                  <form id="practice-form" class="form-grid">
+                    <div class="form-card">
+                      <h3>Session basics</h3>
+                      <div class="field">
+                        <label for="practice-date">Date</label>
+                        <input id="practice-date" type="date" class="input" value="${new Date().toISOString().split('T')[0]}">
+                      </div>
+                      <div class="field">
+                        <label for="practice-type">Session type</label>
+                        <select id="practice-type" class="input">
+                          <option value="mixed">Mixed work</option>
+                          <option value="technique">Technique focus</option>
+                          <option value="live">Live wrestling</option>
+                          <option value="conditioning">Conditioning</option>
+                          <option value="competition">Competition</option>
+                          <option value="open-mat">Open mat</option>
+                        </select>
+                      </div>
+                      <div class="field">
+                        <span class="label">Duration presets</span>
+                        <div class="chip-row">
+                          <button type="button" class="chip" data-duration="60">60 min</button>
+                          <button type="button" class="chip" data-duration="90">90 min</button>
+                          <button type="button" class="chip" data-duration="120">120 min</button>
+                        </div>
+                      </div>
+                      <div class="field">
+                        <label for="practice-duration">Manual duration (minutes)</label>
+                        <input id="practice-duration" type="number" min="1" inputmode="numeric" class="input" placeholder="75">
                       </div>
                     </div>
-                    <button class="delete-btn" data-id="${p.id}">✕</button>
-                  </li>
-                `).join('')}
-              </ul>
-            </div>
-            
-            <!-- Badges Section (Show Only Earned) -->
-            <div id="section-badges" class="section ${currentTab === 'badges' ? 'active' : ''}">
-              <h2>Earned Badges (${profile.earnedBadges.length} of ${ALL_BADGES.length})</h2>
-              <div class="badges">
-                ${ALL_BADGES.filter(badge => profile.earnedBadges.some(b => b.id === badge.id)).map(badge => {
-                    const earned = profile.earnedBadges.find(b => b.id === badge.id);
-                    return `
-                        <div class="badge earned">
-                            ${badge.icon} ${badge.name}
-                            <div class="badge-meta">Practice #${earned.practiceNumber}</div>
+
+                    <div class="form-card">
+                      <h3>How did it feel?</h3>
+                      <div class="field field-slider">
+                        <label for="practice-intensity">Intensity</label>
+                        <div class="slider-wrap">
+                          <input id="practice-intensity" type="range" min="1" max="10" value="5" class="input range">
+                          <span id="intensity-value" class="slider-value">5</span>
                         </div>
-                    `;
-                }).join('')}
-              </div>
-            </div>
-
-            <!-- Journey Guide Section (Static Text) -->
-            <div id="section-guide" class="section ${currentTab === 'guide' ? 'active' : ''}">
-                <h2>Wrestling Journey Guide</h2>
-                ${PHASES.map(phase => `
-                    <div class="stat-card" style="margin-bottom: 1rem;">
-                        <h3>Phase ${phase.id}: ${phase.name} (Goal: ${phase.goal} Practices)</h3>
-                        <p style="font-size: 1rem; color: var(--color-text-light); margin-top: 0.5rem;">${phase.description}</p>
+                      </div>
+                      <div class="field field-slider">
+                        <label for="practice-physical">Physical feel</label>
+                        <div class="slider-wrap">
+                          <input id="practice-physical" type="range" min="1" max="10" value="5" class="input range">
+                          <span id="physical-value" class="slider-value">5</span>
+                        </div>
+                      </div>
+                      <div class="field field-slider">
+                        <label for="practice-mental">Mental feel</label>
+                        <div class="slider-wrap">
+                          <input id="practice-mental" type="range" min="1" max="10" value="5" class="input range">
+                          <span id="mental-value" class="slider-value">5</span>
+                        </div>
+                      </div>
                     </div>
-                `).join('')}
-            </div>
 
-            <!-- Settings Section -->
-            <div id="section-settings" class="section ${currentTab === 'settings' ? 'active' : ''}">
-                <h2>Settings & Data Management</h2>
-                <div class="input-group" style="margin-bottom: 0.5rem;">
-                    <button id="export-btn" class="button">Export Data (JSON)</button>
-                    <button id="clear-btn" class="button" style="background-color: #dc2626;">Clear All Data</button>
-                </div>
-                <p style="font-size: 0.9rem; color: var(--color-text-muted);">Warning: Clearing data cannot be undone and removes all practices and badges.</p>
-                
-                <h3>Import Data</h3>
-                <input type="file" id="import-file" accept="application/json" class="input" style="padding: 0.75rem 0.5rem;">
-                <button id="import-btn" class="button">Import JSON</button>
-            </div>
+                    <div class="form-card">
+                      <h3>Notes for future you</h3>
+                      <div class="field">
+                        <label for="practice-notes">Key takeaways</label>
+                        <textarea id="practice-notes" class="input textarea" rows="4" placeholder="What clicked? What felt off? Be specific so future sessions improve."></textarea>
+                      </div>
+                    </div>
 
-            <!-- Journey Guide is now a separate section -->
+                    <div class="form-actions">
+                      <button type="submit" class="button">Save practice</button>
+                      <button type="button" class="button ghost" data-switch-to="dashboard">Cancel</button>
+                    </div>
+                  </form>
+                </article>
+              </section>
+
+              <!-- History -->
+              <section id="section-history" class="section ${currentTab === 'history' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
+                    <div>
+                      <h2>Practice history</h2>
+                      <p class="panel-subtitle">Scroll through the work. No shortcuts, just honest reps.</p>
+                    </div>
+                    <span class="phase-chip subtle">${practices.length} logged</span>
+                  </div>
+                  ${practices.length ? `
+                    <ul id="practice-list" class="practice-list">
+                      ${practices.slice().reverse().map(p => `
+                        <li class="practice-card" data-id="${p.id}">
+                          <div class="practice-card-header">
+                            <span class="practice-type">${p.type}</span>
+                            <time class="practice-date">${new Date(p.date).toLocaleDateString()}</time>
+                          </div>
+                          <p class="practice-notes">${p.notes}</p>
+                          <div class="practice-metrics">
+                            ${p.duration ? `<span>${p.duration} min</span>` : ''}
+                            ${p.intensity ? `<span>Intensity ${p.intensity}/10</span>` : ''}
+                            ${typeof p.physical === 'number' ? `<span>Physical ${p.physical}/10</span>` : ''}
+                            ${typeof p.mental === 'number' ? `<span>Mental ${p.mental}/10</span>` : ''}
+                          </div>
+                          <button class="delete-btn" data-id="${p.id}">Delete</button>
+                        </li>
+                      `).join('')}
+                    </ul>
+                  ` : '<div class="empty">No sessions logged yet. Start with today\'s practice.</div>'}
+                </article>
+              </section>
+
+              <!-- Badges -->
+              <section id="section-badges" class="section ${currentTab === 'badges' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
+                    <div>
+                      <h2>Earned badges</h2>
+                      <p class="panel-subtitle">Consistency over hype. Each badge marks a real milestone.</p>
+                    </div>
+                    <span class="phase-chip subtle">${earnedBadges.length} / ${ALL_BADGES.length}</span>
+                  </div>
+                  <div class="badge-grid">
+                    ${ALL_BADGES.map(badge => {
+                      const earned = earnedBadges.find(b => b.id === badge.id);
+                      return `
+                        <div class="badge-card ${earned ? 'earned' : ''}">
+                          <span class="badge-icon">${BADGE_ICONS[badge.id] || '🥋'}</span>
+                          <h3>${badge.name}</h3>
+                          <p class="badge-description">${badge.description}</p>
+                          ${earned ? `<p class="badge-earned">Unlocked ${new Date(earned.earnedDate).toLocaleDateString()} · Practice #${earned.practiceNumber}</p>` : '<p class="badge-earned">Keep grinding to unlock.</p>'}
+                        </div>
+                      `;
+                    }).join('')}
+                  </div>
+                </article>
+              </section>
+
+              <!-- Journey Guide -->
+              <section id="section-guide" class="section ${currentTab === 'guide' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
+                    <h2>Journey guide</h2>
+                    <p class="panel-subtitle">Phases explain what to expect. No promises, just direction.</p>
+                  </div>
+                  <div class="guide-grid">
+                    ${PHASES.map(phase => `
+                      <div class="guide-card">
+                        <p class="eyebrow">Phase ${phase.id}</p>
+                        <h3>${phase.name}</h3>
+                        <p class="guide-goal">Goal: ${phase.goal} logged practices</p>
+                        <p class="guide-description">${phase.description}</p>
+                      </div>
+                    `).join('')}
+                  </div>
+                </article>
+              </section>
+
+              <!-- Settings -->
+              <section id="section-settings" class="section ${currentTab === 'settings' ? 'active' : ''}">
+                <article class="panel">
+                  <div class="panel-header">
+                    <h2>Data & settings</h2>
+                    <p class="panel-subtitle">Your data stays on-device. Export for backups, clear when needed.</p>
+                  </div>
+                  <div class="settings-actions">
+                    <button id="export-btn" class="button secondary">Export JSON</button>
+                    <button id="clear-btn" class="button danger">Clear all data</button>
+                  </div>
+                  <div class="settings-import">
+                    <label for="import-file">Import saved data</label>
+                    <input type="file" id="import-file" accept="application/json" class="input">
+                    <button id="import-btn" class="button ghost">Import JSON</button>
+                  </div>
+                  <p class="settings-note">Clearing data removes every practice and badge. There are no take-backs.</p>
+                </article>
+              </section>
+            </main>
           </div>
         `;
 
@@ -276,8 +374,16 @@
         document.getElementById('practice-mental').addEventListener('input', () => updateSliderValue('mental'));
         document.querySelectorAll('.tab').forEach(btn => btn.addEventListener('click', switchTab));
         document.querySelectorAll('.delete-btn').forEach(btn => btn.addEventListener('click', handleDeletePractice));
-        document.querySelectorAll('.preset-btn').forEach(btn => btn.addEventListener('click', handleDurationPreset));
-        
+        document.querySelectorAll('.chip').forEach(btn => btn.addEventListener('click', handleDurationPreset));
+        document.querySelectorAll('[data-switch-to]').forEach(btn => btn.addEventListener('click', quickSwitch));
+        const heroButton = document.getElementById('hero-log-btn');
+        if (heroButton) {
+          heroButton.addEventListener('click', () => {
+            currentTab = 'log';
+            render();
+          });
+        }
+
         // Settings Listeners
         document.getElementById('export-btn').addEventListener('click', handleExportData);
         document.getElementById('clear-btn').addEventListener('click', handleClearData);
@@ -296,6 +402,14 @@
       
       function handleDurationPreset(e) {
           document.getElementById('practice-duration').value = e.target.dataset.duration;
+      }
+
+      function quickSwitch(e) {
+        const target = e.currentTarget.getAttribute('data-switch-to');
+        if (target) {
+          currentTab = target;
+          render();
+        }
       }
 
       async function handleAddPractice(e) {
@@ -330,9 +444,9 @@
         document.getElementById('practice-form').reset();
         document.getElementById('practice-date').value = new Date().toISOString().split('T')[0];
         document.getElementById('practice-intensity').value = 5;
-        document.getElementById('practice-physical').value = 3;
-        document.getElementById('practice-mental').value = 3;
-        
+        document.getElementById('practice-physical').value = 5;
+        document.getElementById('practice-mental').value = 5;
+
         // Switch to Dashboard and re-render
         currentTab = 'dashboard';
         render();

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,255 +1,124 @@
-/* --- CSS Variables for Polish and Consistency --- */
+* {
+  box-sizing: border-box;
+}
+
 :root {
-  --color-primary: #ea580c; /* Orange Accent */
-  --color-secondary: #f97316; /* Lighter Orange */
-  --color-dark-bg: #111827; /* Very Dark Blue */
-  --color-card-bg: #1f2937; /* Dark Blue-Gray for cards */
-  --color-input-bg: #374151; /* Softer Dark Gray for inputs */
+  --color-primary: #ea580c;
+  --color-secondary: #f97316;
+  --color-dark-bg: #111827;
+  --color-card-bg: #1f2937;
+  --color-input-bg: #374151;
   --color-text-light: #f3f4f6;
   --color-text-muted: #9ca3af;
   --color-border: #4b5563;
-  
+  --color-danger: #ef4444;
+
   --spacing-unit: 1rem;
-  --border-radius-card: 12px;
-  --border-radius-sm: 6px;
+  --border-radius-card: 16px;
+  --border-radius-sm: 8px;
   --tap-target-min: 48px;
   --transition-speed: 0.2s;
 }
 
-/* --- Base & Typography --- */
 body {
   margin: 0;
-  /* Modern, legible font stack */
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  line-height: 1.6; /* Increased line height for readability */
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
   color: var(--color-text-light);
-  /* Rich dark background gradient */
-  background: linear-gradient(180deg, var(--color-dark-bg) 0%, #0c1017 100%);
+  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.6), rgba(15, 23, 42, 0.95)),
+    linear-gradient(180deg, var(--color-dark-bg) 0%, #0b1120 100%);
   min-height: 100vh;
 }
 
 .app {
-  padding: var(--spacing-unit);
-  max-width: 600px;
-  margin: 0 auto;
+  padding: 1.5rem;
+  max-width: 760px;
+  margin: 0 auto 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: linear-gradient(160deg, rgba(26, 35, 51, 0.9), rgba(17, 24, 39, 0.85));
+  border-radius: 24px;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 24px 60px rgba(8, 12, 24, 0.65);
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hero-tag {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-muted);
 }
 
 .title {
-  font-size: 2rem;
-  font-weight: 700;
-  margin-top: var(--spacing-unit);
-  margin-bottom: calc(2 * var(--spacing-unit));
-  color: var(--color-primary);
-  text-align: center;
-}
-
-/* --- Input Group & Form Elements --- */
-.input-group {
-  margin-bottom: calc(2 * var(--spacing-unit));
-  display: flex;
-  gap: var(--spacing-unit);
-  flex-direction: column; /* Default to stack for mobile */
-}
-
-@media (min-width: 450px) {
-  .input-group {
-    flex-direction: row; /* Side-by-side on wider screens */
-  }
-  .button {
-    margin-top: 0;
-  }
-}
-
-.input {
-  width: 100%;
-  padding: 0.75rem;
-  background-color: var(--color-input-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-sm);
-  color: var(--color-text-light);
-  transition: border-color var(--transition-speed), box-shadow var(--transition-speed);
-  flex-grow: 1;
-  font-size: 1rem;
-}
-
-.input:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  /* Focus glow */
-  box-shadow: 0 0 0 3px rgba(234, 88, 12, 0.4); 
-}
-
-/* --- Buttons --- */
-.button {
-  min-height: var(--tap-target-min); /* Larger tap target */
-  margin-top: 0.5rem; /* For mobile stacking */
-  /* Gradient background on primary actions */
-  background: linear-gradient(90deg, var(--color-primary), var(--color-secondary));
-  color: var(--color-text-light);
-  font-weight: bold;
-  padding: 0.5rem 1.5rem; 
-  border: none;
-  border-radius: var(--border-radius-sm);
-  cursor: pointer;
-  transition: transform var(--transition-speed), opacity var(--transition-speed), box-shadow var(--transition-speed);
-  flex-shrink: 0;
-  font-size: 1rem;
-}
-
-.button:hover:not(:disabled) {
-  opacity: 0.9;
-  box-shadow: 0 4px 12px rgba(234, 88, 12, 0.3);
-}
-
-.button:active:not(:disabled) {
-  transform: scale(0.98);
-}
-
-
-/* --- Practice List (Cards) --- */
-.practice-list {
-  list-style: none;
-  padding: 0;
   margin: 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--color-primary);
 }
 
-.practice-list li {
-  margin-bottom: var(--spacing-unit);
-  padding: var(--spacing-unit);
-  background-color: var(--color-card-bg);
-  border-radius: var(--border-radius-card); /* Rounded corners */
-  /* Subtle box-shadow for depth */
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4); 
-  transition: background-color var(--transition-speed), transform var(--transition-speed);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 1.1rem;
+.hero-subtitle {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-light);
+  max-width: 32ch;
 }
 
-.practice-list li:hover {
-  background-color: #2b394d; /* Subtle hover highlight */
-  transform: translateY(-2px);
+.hero-action {
+  align-self: flex-start;
 }
 
-.practice-item-text {
-  flex-grow: 1;
-  line-clamp: 2;
-  margin-right: var(--spacing-unit);
-}
-
-.practice-item-date {
-  font-size: 0.9rem;
-  color: var(--color-text-muted); /* Muted grey date */
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-
-/* --- Custom Slider Styles (for future use/modularity) --- */
-input[type="range"] {
-  -webkit-appearance: none;
-  width: 100%;
-  height: 8px;
-  border-radius: 5px;
-  background: #3f3f46;
-  outline: none;
-  transition: background var(--transition-speed);
-}
-
-input[type="range"]:focus {
-  outline: none;
-  /* Orange accent focus */
-  box-shadow: 0 0 0 3px rgba(234, 88, 12, 0.4); 
-}
-
-input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--color-primary);
-  cursor: pointer;
-  transition: background var(--transition-speed), transform var(--transition-speed);
-}
-
-input[type="range"]::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--color-primary);
-  cursor: pointer;
-  border: none;
-  transition: background var(--transition-speed);
-}
-
-input[type="range"]::-webkit-slider-thumb:hover,
-input[type="range"]::-moz-range-thumb:hover {
-  background: var(--color-secondary);
-  transform: scale(1.1);
-}
-
-
-/* --- Utility Styles --- */
-
-/* Line clamp utility */
-.line-clamp-2 {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-/* Hide scrollbar but keep functionality */
-::-webkit-scrollbar {
-  width: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: #18181b;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #3f3f46;
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #52525b;
-}
-
-/* --- Tabs --- */
 .tabs {
   display: flex;
-  /* Ensure all tabs fit on one line for small screens */
-  overflow-x: auto; 
+  overflow-x: auto;
   white-space: nowrap;
-  margin-bottom: var(--spacing-unit);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding-bottom: 0.25rem;
+  gap: 0.5rem;
 }
 
 .tab {
   flex: 1;
-  min-width: 80px; /* Ensure small tabs are still tappable */
-  padding: 0.5rem;
+  min-width: 90px;
+  padding: 0.6rem 0.5rem;
   background: none;
   border: none;
+  border-radius: var(--border-radius-sm);
   color: var(--color-text-muted);
+  font-weight: 600;
+  letter-spacing: 0.02em;
   cursor: pointer;
-  transition: var(--transition-speed);
+  transition: color var(--transition-speed), background var(--transition-speed);
 }
 
 .tab.active {
   color: var(--color-primary);
-  border-bottom: 2px solid var(--color-primary);
+  background: rgba(234, 88, 12, 0.16);
 }
 
 .tab:hover {
   color: var(--color-text-light);
 }
 
-/* --- Sections --- */
+.panels {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .section {
   display: none;
 }
@@ -258,206 +127,578 @@ input[type="range"]::-moz-range-thumb:hover {
   display: block;
 }
 
-/* --- Form Elements --- */
-.form-row {
+.panel {
+  background: rgba(23, 31, 48, 0.9);
+  border-radius: var(--border-radius-card);
+  padding: 1.5rem;
   display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 20px 45px rgba(7, 12, 24, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.panel-header h2,
+.panel-header h3 {
+  margin: 0;
+}
+
+.panel-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.eyebrow {
+  margin: 0 0 0.3rem 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--color-text-muted);
+}
+
+.phase-chip {
+  display: inline-flex;
   align-items: center;
-  margin-bottom: var(--spacing-unit);
-  gap: var(--spacing-unit);
-  flex-wrap: wrap; /* Allow wrapping on very small screens */
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  background: rgba(234, 88, 12, 0.18);
+  border-radius: 999px;
+  color: var(--color-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
 }
 
-.form-row label {
-  flex-shrink: 0;
-  min-width: 150px; /* Ensure labels align */
-  font-size: 0.9rem;
+.phase-chip.subtle {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text-muted);
 }
 
-.form-row-full {
-    display: block;
+.progress-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
 }
 
-.form-row-full label {
-    display: block;
-    margin-bottom: 0.25rem;
+.progress-ring {
+  position: relative;
+  width: 120px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: conic-gradient(var(--color-primary) var(--progress, 0%), rgba(75, 85, 99, 0.45) var(--progress, 0%));
+  display: grid;
+  place-items: center;
 }
 
-.form-row-slider .input.range {
-    flex-grow: 1;
-    max-width: none;
+.progress-ring::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 50%;
 }
 
-.form-row-slider span {
-  font-weight: bold;
-  color: var(--color-primary);
-  min-width: 20px;
-  text-align: center;
+.progress-ring span {
+  position: relative;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-.duration-presets div {
-    display: flex;
-    gap: 0.5rem;
+.progress-details {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
-.preset-btn {
-    flex: 1;
-    min-height: 40px;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.9rem;
-    background: var(--color-input-bg);
-    color: var(--color-text-light);
+.progress-count {
+  margin: 0;
+  font-weight: 600;
 }
 
-.preset-btn:hover {
-    background: var(--color-primary);
-    box-shadow: none;
+.progress-note,
+.progress-last {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .dashboard-actions {
+    flex-direction: row;
+  }
+}
+
+.button {
+  min-height: var(--tap-target-min);
+  padding: 0.65rem 1.5rem;
+  border-radius: var(--border-radius-sm);
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(100deg, var(--color-primary), var(--color-secondary));
+  color: var(--color-text-light);
+  font-weight: 600;
+  font-size: 1rem;
+  transition: transform var(--transition-speed), box-shadow var(--transition-speed), opacity var(--transition-speed);
+}
+
+.button:hover:not(:disabled) {
+  opacity: 0.92;
+  box-shadow: 0 12px 24px rgba(234, 88, 12, 0.35);
+}
+
+.button:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.button.secondary {
+  background: rgba(55, 65, 81, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.button.ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.button.danger {
+  background: linear-gradient(100deg, var(--color-danger), #b91c1c);
+}
+
+.button-link {
+  background: none;
+  border: none;
+  color: var(--color-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  min-height: auto;
+}
+
+.button-link:hover {
+  color: var(--color-text-light);
+}
+
+.input {
+  width: 100%;
+  padding: 0.8rem;
+  background: var(--color-input-bg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--border-radius-sm);
+  color: var(--color-text-light);
+  font-size: 1rem;
+  transition: border-color var(--transition-speed), box-shadow var(--transition-speed);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(234, 88, 12, 0.3);
 }
 
 .textarea {
   resize: vertical;
-  min-height: 80px;
-  width: 100%; /* Ensure textarea fills width */
+  min-height: 100px;
 }
 
-.input-group.form-row-full {
-    /* Reset flex for the Log Practice button */
-    display: block; 
+input[type="range"] {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(63, 63, 70, 0.8);
+  outline: none;
 }
 
-/* --- Practice List --- */
-.practice-list li {
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+  transition: transform var(--transition-speed);
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.06);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-primary);
+  cursor: pointer;
+}
+
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-card {
+  background: rgba(46, 56, 76, 0.65);
+  border-radius: var(--border-radius-card);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field label,
+.field .label,
+.settings-import label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  background: rgba(55, 65, 81, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--color-text-light);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background var(--transition-speed), transform var(--transition-speed);
+}
+
+.chip:hover {
+  background: rgba(234, 88, 12, 0.3);
+}
+
+.chip:active {
+  transform: scale(0.97);
+}
+
+.field-slider .slider-wrap {
   display: flex;
   align-items: center;
-  gap: var(--spacing-unit);
-  padding: var(--spacing-unit);
-  background-color: var(--color-card-bg);
-  border-radius: var(--border-radius-card);
-  margin-bottom: var(--spacing-unit);
+  gap: 0.75rem;
 }
 
-.practice-content {
-  flex: 1;
+.slider-value {
+  min-width: 2ch;
+  font-weight: 700;
+  color: var(--color-secondary);
 }
 
-.practice-meta {
+.form-actions {
   display: flex;
-  gap: var(--spacing-unit);
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  margin-top: 0.25rem;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
 }
 
-.delete-btn {
-  background: none;
-  border: none;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  font-size: 1.2rem;
-  padding: 0.25rem;
-  border-radius: var(--border-radius-sm);
-  transition: var(--transition-speed);
+@media (min-width: 640px) {
+  .form-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
 }
 
-.delete-btn:hover {
-  background-color: #dc2626;
-  color: white;
-}
-
-/* --- Stats --- */
-.stats {
+.stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: var(--spacing-unit);
-  margin-top: var(--spacing-unit);
+  gap: 1rem;
 }
 
 .stat-card {
-  padding: var(--spacing-unit);
-  background-color: var(--color-card-bg);
+  background: rgba(46, 56, 76, 0.55);
   border-radius: var(--border-radius-card);
-  text-align: center;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
-.stat-card h3 {
-  margin: 0 0 0.5rem 0;
+.stat-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.stat-value {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.badge-shelf {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.badge-token {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  background: rgba(46, 56, 76, 0.6);
+  border-radius: var(--border-radius-card);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.badge-icon {
+  font-size: 1.75rem;
+}
+
+.badge-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.badge-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.badge-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.badge-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.badge-card {
+  background: rgba(46, 56, 76, 0.55);
+  border-radius: var(--border-radius-card);
+  padding: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.badge-card.earned {
+  border-color: rgba(234, 88, 12, 0.55);
+  background: rgba(234, 88, 12, 0.18);
+}
+
+.badge-description,
+.badge-earned {
+  margin: 0;
   font-size: 0.9rem;
   color: var(--color-text-muted);
 }
 
-.stat-card p {
+.practice-list {
+  list-style: none;
+  padding: 0;
   margin: 0;
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: var(--color-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-/* --- Badges --- */
-.badges {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: var(--spacing-unit);
-  margin-top: var(--spacing-unit);
-}
-
-.badge {
-  padding: var(--spacing-unit);
-  background-color: var(--color-card-bg);
+.practice-card {
+  background: rgba(46, 56, 76, 0.6);
   border-radius: var(--border-radius-card);
-  text-align: center;
-  opacity: 0.5;
-  transition: var(--transition-speed);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
 }
 
-.badge.earned {
-  opacity: 1;
-  background-color: var(--color-primary);
-  color: white;
+.practice-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-/* --- Journey Guide --- */
-/* (Changed the section content to better reflect the AI-ready prompt) */
-#section-guide .stat-card {
-    /* Reuse stat card for phase descriptions */
-    padding: var(--spacing-unit);
-    background-color: var(--color-card-bg);
-    border-radius: var(--border-radius-card);
-    text-align: left;
-}
-
-/* --- Progress Bar --- */
-.progress-bar-container {
-    height: 12px;
-    background-color: var(--color-card-bg);
-    border-radius: var(--border-radius-card);
-    overflow: hidden;
-    margin-bottom: 0.5rem;
-}
-
-.progress-bar {
-    height: 100%;
-    background-color: var(--color-primary);
-    transition: width 0.5s ease-in-out;
-}
-
-.progress-label {
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
-    margin-bottom: calc(2 * var(--spacing-unit));
-}
-
-
-/* --- Practice Item Variants --- */
-.practice-item-type {
-  background-color: var(--color-primary);
-  color: white;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--border-radius-sm);
-  font-size: 0.7rem;
+.practice-type {
   text-transform: capitalize;
+  background: rgba(234, 88, 12, 0.25);
+  color: var(--color-secondary);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
-.practice-item-intensity {
-  font-weight: bold;
-  color: var(--color-primary);
+.practice-date {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.practice-notes {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.practice-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.delete-btn {
+  align-self: flex-end;
+  background: none;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #fca5a5;
+  border-radius: var(--border-radius-sm);
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  transition: background var(--transition-speed);
+}
+
+.delete-btn:hover {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.guide-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.guide-card {
+  background: rgba(46, 56, 76, 0.55);
+  border-radius: var(--border-radius-card);
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.guide-goal,
+.guide-description {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.settings-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-import {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.settings-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(71, 85, 105, 0.8);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.8);
+}
+
+@media (min-width: 640px) {
+  .hero {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .hero-action {
+    margin-top: 0;
+  }
+
+  .badge-shelf {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .badge-token {
+    flex: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+  }
+
+  .form-card:nth-child(3) {
+    grid-column: span 2;
+  }
+
+  .form-actions {
+    grid-column: span 2;
+  }
+
+  .guide-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the dashboard as a mobile-first layout with hero banner, progress ring, stats, and badge shelf focused on the next milestone
- redesign the practice logging flow into card-based sections with quick duration presets and accessible sliders aligned with the truth document
- refresh the site-wide dark-mode styling for better spacing, tap targets, and card presentations across history, badges, guide, and settings views

## Testing
- Manual verification in browser (Pixel 8 viewport)


------
https://chatgpt.com/codex/tasks/task_e_68dd627aabbc8323aa4457883e0859ba