### PR TITLE
Revamp badge system to follow milestone vision

### DIFF
--- a/docs/db.js
+++ b/docs/db.js
@@ -132,110 +132,504 @@ openDB();
 
 // --- BADGE SYSTEM ---
 
-export const ALL_BADGES = [
-    {
-        id: 1,
-        name: 'First Practice',
-        description: 'Complete your first practice session',
-        check: (practices) => practices.length >= 1
-    },
-    {
-        id: 2,
-        name: '10 Practices',
-        description: 'Complete 10 practice sessions',
-        check: (practices) => practices.length >= 10
-    },
-    {
-        id: 3,
-        name: '50 Practices',
-        description: 'Complete 50 practice sessions',
-        check: (practices) => practices.length >= 50
-    },
-    {
-        id: 4,
-        name: 'High Intensity',
-        description: 'Average intensity of 4+ over 5 sessions',
-        check: (practices) => {
-            if (practices.length < 5) return false;
-            const totalIntensity = practices.reduce((sum, p) => sum + (p.intensity || 0), 0);
-            const avgIntensity = totalIntensity / practices.length;
-            return avgIntensity >= 4;
+const BADGE_ID_MIGRATIONS = {
+    '1': 'first_practice',
+    '2': 'ten_practices',
+    '3': 'fifty_practices',
+    '4': 'high_intensity_focus'
+};
+
+function uniqueSortedPracticeDates(practices) {
+    const uniqueDates = Array.from(new Set(practices
+        .map(p => p.date)
+        .filter(Boolean)));
+    return uniqueDates
+        .map(dateStr => new Date(dateStr))
+        .filter(date => !isNaN(date.getTime()))
+        .sort((a, b) => a - b);
+}
+
+function calculateStreaks(practices) {
+    const dates = uniqueSortedPracticeDates(practices);
+    if (!dates.length) {
+        return { current: 0, longest: 0 };
+    }
+
+    let current = 1;
+    let longest = 1;
+
+    for (let i = 1; i < dates.length; i++) {
+        const diffDays = Math.round((dates[i] - dates[i - 1]) / (1000 * 60 * 60 * 24));
+        if (diffDays === 1) {
+            current += 1;
+        } else {
+            current = 1;
         }
+        if (current > longest) {
+            longest = current;
+        }
+    }
+
+    const lastPractice = dates[dates.length - 1];
+    const today = new Date();
+    const daysSinceLastPractice = Math.round((today.setHours(0, 0, 0, 0) - lastPractice.setHours(0, 0, 0, 0)) / (1000 * 60 * 60 * 24));
+
+    return {
+        current: daysSinceLastPractice <= 1 ? current : 0,
+        longest
+    };
+}
+
+function countPracticesInWindow(practices, days) {
+    if (!practices.length) {
+        return 0;
+    }
+
+    const cutoff = new Date();
+    cutoff.setHours(0, 0, 0, 0);
+    cutoff.setDate(cutoff.getDate() - (days - 1));
+
+    return practices.filter(p => {
+        if (!p.date) return false;
+        const practiceDate = new Date(p.date);
+        if (isNaN(practiceDate.getTime())) return false;
+        practiceDate.setHours(0, 0, 0, 0);
+        return practiceDate >= cutoff;
+    }).length;
+}
+
+function calculatePracticeStats(practices) {
+    const practiceCount = practices.length;
+    const totalMinutes = practices.reduce((sum, p) => sum + (Number(p.duration) || 0), 0);
+    const totalHours = totalMinutes / 60;
+    const intensitySamples = practices.slice(-5);
+    const avgRecentIntensity = intensitySamples.length
+        ? intensitySamples.reduce((sum, p) => sum + (Number(p.intensity) || 0), 0) / intensitySamples.length
+        : 0;
+    const streaks = calculateStreaks(practices);
+
+    return {
+        practiceCount,
+        totalMinutes,
+        totalHours,
+        avgRecentIntensity,
+        streaks,
+        last7Days: countPracticesInWindow(practices, 7),
+        last14Days: countPracticesInWindow(practices, 14),
+        last30Days: countPracticesInWindow(practices, 30)
+    };
+}
+
+export const ALL_BADGES = [
+    // Volume milestones (frequent early wins → spaced out later)
+    {
+        id: 'first_practice',
+        name: 'Day One',
+        description: 'Log your very first practice.',
+        icon: '🏅',
+        category: 'volume',
+        milestone: 1,
+        check: (stats) => stats.practiceCount >= 1
+    },
+    {
+        id: 'three_practices',
+        name: 'Three Days In',
+        description: 'Keep the spark alive with three logged practices.',
+        icon: '✨',
+        category: 'volume',
+        milestone: 3,
+        check: (stats) => stats.practiceCount >= 3
+    },
+    {
+        id: 'five_practices',
+        name: 'First Week',
+        description: 'Five practices logged. You survived week one.',
+        icon: '🔥',
+        category: 'volume',
+        milestone: 5,
+        check: (stats) => stats.practiceCount >= 5
+    },
+    {
+        id: 'ten_practices',
+        name: 'Two Weeks Strong',
+        description: 'Ten sessions entered. Momentum is building.',
+        icon: '💪',
+        category: 'volume',
+        milestone: 10,
+        check: (stats) => stats.practiceCount >= 10
+    },
+    {
+        id: 'fifteen_practices',
+        name: 'Three Weeks In',
+        description: 'Fifteen logged practices. Showing up matters.',
+        icon: '🏋️',
+        category: 'volume',
+        milestone: 15,
+        check: (stats) => stats.practiceCount >= 15
+    },
+    {
+        id: 'twenty_practices',
+        name: 'First Month',
+        description: 'Twenty honest sessions. A full month of work.',
+        icon: '📆',
+        category: 'volume',
+        milestone: 20,
+        check: (stats) => stats.practiceCount >= 20
+    },
+    {
+        id: 'thirty_practices',
+        name: 'Six Weeks Strong',
+        description: 'Thirty practices logged. The habit is real.',
+        icon: '🛡️',
+        category: 'volume',
+        milestone: 30,
+        check: (stats) => stats.practiceCount >= 30
+    },
+    {
+        id: 'forty_practices',
+        name: 'Two Months Deep',
+        description: 'Forty practices. You kept the promise to yourself.',
+        icon: '⚙️',
+        category: 'volume',
+        milestone: 40,
+        check: (stats) => stats.practiceCount >= 40
+    },
+    {
+        id: 'fifty_practices',
+        name: 'Quarter Season',
+        description: 'Fifty sessions of grind logged.',
+        icon: '🥇',
+        category: 'volume',
+        milestone: 50,
+        check: (stats) => stats.practiceCount >= 50
+    },
+    {
+        id: 'seventyfive_practices',
+        name: 'Crucible Complete',
+        description: 'Seventy-five practices. Phase one survived.',
+        icon: '🔥',
+        category: 'phase',
+        milestone: 75,
+        check: (stats) => stats.practiceCount >= 75
+    },
+    {
+        id: 'hundred_practices',
+        name: 'Century Club',
+        description: 'One hundred logged practices. The grind is real.',
+        icon: '💯',
+        category: 'volume',
+        milestone: 100,
+        check: (stats) => stats.practiceCount >= 100
+    },
+    {
+        id: 'hundredfifty_practices',
+        name: 'Half Year',
+        description: 'One hundred and fifty practices documented.',
+        icon: '🛠️',
+        category: 'volume',
+        milestone: 150,
+        check: (stats) => stats.practiceCount >= 150
+    },
+    {
+        id: 'twohundred_practices',
+        name: 'Grinder Complete',
+        description: 'Two hundred practices. The foundation is set.',
+        icon: '🏆',
+        category: 'phase',
+        milestone: 200,
+        check: (stats) => stats.practiceCount >= 200
+    },
+    {
+        id: 'threehundred_practices',
+        name: 'Year and a Half',
+        description: 'Three hundred practices. Flow is taking shape.',
+        icon: '🌊',
+        category: 'volume',
+        milestone: 300,
+        check: (stats) => stats.practiceCount >= 300
+    },
+    {
+        id: 'fourhundred_practices',
+        name: 'Two Years In',
+        description: 'Four hundred entries. You live on the mat.',
+        icon: '🧱',
+        category: 'volume',
+        milestone: 400,
+        check: (stats) => stats.practiceCount >= 400
+    },
+    {
+        id: 'fivehundred_practices',
+        name: 'Technician Complete',
+        description: 'Five hundred tracked practices. Flow unlocked.',
+        icon: '⚡',
+        category: 'phase',
+        milestone: 500,
+        check: (stats) => stats.practiceCount >= 500
+    },
+    {
+        id: 'sevenfifty_practices',
+        name: 'Relentless',
+        description: 'Seven hundred and fifty sessions. Momentum never left.',
+        icon: '🌀',
+        category: 'volume',
+        milestone: 750,
+        check: (stats) => stats.practiceCount >= 750
+    },
+    {
+        id: 'thousand_practices',
+        name: 'Competitor Complete',
+        description: 'One thousand logged practices. Advanced level engaged.',
+        icon: '🥋',
+        category: 'phase',
+        milestone: 1000,
+        check: (stats) => stats.practiceCount >= 1000
+    },
+    {
+        id: 'fifteenhundred_practices',
+        name: 'Grind Veteran',
+        description: 'Fifteen hundred practices. You outlasted seasons.',
+        icon: '🛡️',
+        category: 'volume',
+        milestone: 1500,
+        check: (stats) => stats.practiceCount >= 1500
+    },
+    {
+        id: 'two_thousand_practices',
+        name: 'Advanced Complete',
+        description: 'Two thousand recorded sessions. Elite territory.',
+        icon: '🏔️',
+        category: 'phase',
+        milestone: 2000,
+        check: (stats) => stats.practiceCount >= 2000
+    },
+    {
+        id: 'veteran_status',
+        name: 'Veteran Status',
+        description: 'Keep logging beyond two thousand practices.',
+        icon: '🧭',
+        category: 'phase',
+        milestone: 2500,
+        check: (stats) => stats.practiceCount >= 2500
+    },
+
+    // Consistency badges
+    {
+        id: 'streak_three',
+        name: 'Three Practice Streak',
+        description: 'Three consecutive training days logged.',
+        icon: '📈',
+        category: 'consistency',
+        check: (stats) => stats.streaks.current >= 3
+    },
+    {
+        id: 'streak_five',
+        name: 'Five Practice Streak',
+        description: 'Five straight days putting in work.',
+        icon: '🎯',
+        category: 'consistency',
+        check: (stats) => stats.streaks.current >= 5
+    },
+    {
+        id: 'streak_ten',
+        name: 'Ten Practice Streak',
+        description: 'Ten consecutive training days documented.',
+        icon: '🚀',
+        category: 'consistency',
+        check: (stats) => stats.streaks.current >= 10
+    },
+    {
+        id: 'two_weeks_consistent',
+        name: 'Two Weeks Consistent',
+        description: 'Six or more practices in the last two weeks.',
+        icon: '📆',
+        category: 'consistency',
+        check: (stats) => stats.last14Days >= 6
+    },
+    {
+        id: 'month_of_work',
+        name: 'Month of Work',
+        description: 'Twelve or more practices this month.',
+        icon: '🧮',
+        category: 'consistency',
+        check: (stats) => stats.last30Days >= 12
+    },
+    {
+        id: 'weekly_grind',
+        name: 'Weekly Grind',
+        description: 'Logged four or more sessions in the last seven days.',
+        icon: '🛞',
+        category: 'consistency',
+        check: (stats) => stats.last7Days >= 4
+    },
+
+    // Hours invested badges
+    {
+        id: 'hours_ten',
+        name: 'Ten Hours Logged',
+        description: 'More than ten hours of mat time recorded.',
+        icon: '⏱️',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 10
+    },
+    {
+        id: 'hours_twentyfive',
+        name: 'Twenty-Five Hours',
+        description: 'Twenty-five hours documented in the trenches.',
+        icon: '⌛',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 25
+    },
+    {
+        id: 'hours_fifty',
+        name: 'Fifty Hours',
+        description: 'Fifty hours of focused training tracked.',
+        icon: '🕰️',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 50
+    },
+    {
+        id: 'hours_one_hundred',
+        name: 'One Hundred Hours',
+        description: 'One hundred hours of work logged.',
+        icon: '🏛️',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 100
+    },
+    {
+        id: 'hours_two_fifty',
+        name: 'Quarter Thousand Hours',
+        description: 'Two hundred and fifty hours recorded.',
+        icon: '📡',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 250
+    },
+    {
+        id: 'hours_five_hundred',
+        name: 'Five Hundred Hours',
+        description: 'Five hundred hours of honest training time.',
+        icon: '🧱',
+        category: 'hours',
+        check: (stats) => stats.totalHours >= 500
+    },
+
+    // Effort-focused special badge
+    {
+        id: 'high_intensity_focus',
+        name: 'High Intensity Stretch',
+        description: 'Average intensity 4+ across the last five sessions.',
+        icon: '⚡',
+        category: 'consistency',
+        check: (stats) => stats.avgRecentIntensity >= 4 && stats.practiceCount >= 5
     }
 ];
 
 export function checkBadges(practices, currentProfile) {
-    const earnedBadges = currentProfile.earnedBadges || [];
-    const earnedBadgeIds = earnedBadges.map(b => b.id);
-    
-    // Check each badge to see if it should be earned
-    for (const badge of ALL_BADGES) {
-        if (!earnedBadgeIds.includes(badge.id) && badge.check(practices)) {
-            // New badge earned!
-            const newBadge = {
+    const profile = currentProfile || {};
+    const existingBadges = Array.isArray(profile.earnedBadges) ? profile.earnedBadges : [];
+
+    const normalizedBadges = existingBadges.map(badge => {
+        const migratedId = BADGE_ID_MIGRATIONS[String(badge.id)] || badge.id;
+        return migratedId === badge.id ? badge : { ...badge, id: migratedId };
+    });
+
+    const migrationOccurred = normalizedBadges.some((badge, index) => badge !== existingBadges[index]);
+
+    const stats = calculatePracticeStats(practices);
+    const earnedBadgeIds = new Set(normalizedBadges.map(badge => String(badge.id)));
+    const newlyEarned = [];
+
+    ALL_BADGES.forEach(badge => {
+        if (!earnedBadgeIds.has(badge.id) && badge.check(stats, practices)) {
+            newlyEarned.push({
                 id: badge.id,
                 earnedDate: new Date().toISOString().split('T')[0],
-                practiceNumber: practices.length
-            };
-            
-            return {
-                ...currentProfile,
-                earnedBadges: [...earnedBadges, newBadge]
-            };
+                practiceNumber: stats.practiceCount,
+                category: badge.category
+            });
         }
+    });
+
+    if (!newlyEarned.length && !migrationOccurred) {
+        return null;
     }
-    
-    // No new badges earned
-    return null;
+
+    return {
+        ...profile,
+        earnedBadges: [...normalizedBadges, ...newlyEarned]
+    };
 }
 
 // --- JOURNEY PHASES ---
 
 export const PHASES = [
-    { id: 1, name: 'The Baseline', goal: 10, description: 'Building consistency' },
-    { id: 2, name: 'The Grind', goal: 50, description: 'Developing skills' },
-    { id: 3, name: 'The Competitor', goal: 100, description: 'Mastering the craft' }
+    {
+        id: 1,
+        name: 'The Crucible',
+        description: 'Survival mode. Everything hurts but you keep showing up.',
+        start: 0,
+        goal: 75
+    },
+    {
+        id: 2,
+        name: 'The Grinder',
+        description: 'Foundation building. Technique begins to stick.',
+        start: 75,
+        goal: 200
+    },
+    {
+        id: 3,
+        name: 'The Technician',
+        description: 'Flow develops. You see positions before they happen.',
+        start: 200,
+        goal: 500
+    },
+    {
+        id: 4,
+        name: 'The Competitor',
+        description: 'Advanced level. You hunt openings and capitalize.',
+        start: 500,
+        goal: 1000
+    },
+    {
+        id: 5,
+        name: 'The Advanced',
+        description: 'Elite territory. Sessions sharpen every edge.',
+        start: 1000,
+        goal: 2000
+    },
+    {
+        id: 6,
+        name: 'The Veteran',
+        description: 'Mastery is a moving target. You live this lifestyle.',
+        start: 2000,
+        goal: Infinity
+    }
 ];
 
 export function getPhase(practiceCount) {
-    // Handle negative numbers
-    if (practiceCount < 0) practiceCount = 0;
-    
-    let currentPhase = PHASES[0];
-    let nextPhase = PHASES[0];
-    let progress = 0;
-    
-    // Find current phase
-    for (let i = 0; i < PHASES.length; i++) {
-        if (practiceCount <= PHASES[i].goal) {
-            currentPhase = PHASES[i];
-            
-            // If we're exactly at the goal, next is the next phase
-            if (practiceCount === PHASES[i].goal && i + 1 < PHASES.length) {
-                nextPhase = PHASES[i + 1];
-            } else {
-                nextPhase = PHASES[i];
-            }
-            
-            // Calculate progress within current phase
-            const previousGoal = i > 0 ? PHASES[i - 1].goal : 0;
-            progress = Math.round(((practiceCount - previousGoal) / PHASES[i].goal) * 100);
+    const count = Math.max(0, practiceCount);
+
+    let currentPhase = PHASES[PHASES.length - 1];
+    for (const phase of PHASES) {
+        if (count <= phase.goal) {
+            currentPhase = phase;
             break;
         }
     }
-    
-    // If we've completed all phases
-    if (practiceCount >= PHASES[PHASES.length - 1].goal) {
-        currentPhase = PHASES[PHASES.length - 1];
-    // No next phase once the final goal is reached
-    nextPhase = null;
-        progress = 100;
-    }
-    
+
+    const currentIndex = PHASES.findIndex(phase => phase.id === currentPhase.id);
+    const nextPhase = currentIndex >= 0 && currentIndex < PHASES.length - 1 ? PHASES[currentIndex + 1] : null;
+    const rangeStart = currentPhase.start || 0;
+    const rangeEnd = Number.isFinite(currentPhase.goal) ? currentPhase.goal : rangeStart + Math.max(50, Math.ceil(count / 100) * 25);
+    const denominator = Math.max(1, rangeEnd - rangeStart);
+    const progress = Number.isFinite(currentPhase.goal)
+        ? Math.min(100, Math.max(0, Math.round(((count - rangeStart) / denominator) * 100)))
+        : 100;
+
     return {
         current: currentPhase,
         next: nextPhase,
-        progress: progress
+        progress
     };
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,14 +48,6 @@
       let profile = {};
       let currentTab = 'dashboard';
 
-      // --- JOURNEY DATA & LOGIC ---
-      const BADGE_ICONS = {
-        1: '🏆',
-        2: '🎖️',
-        3: '🥇',
-        4: '⭐'
-      };
-      
       // --- RENDER FUNCTION ---
       async function render() {
         practices = await getPractices();
@@ -77,12 +69,32 @@
           lastPracticeDate: practices.length ? new Date(practices.slice(-1)[0].date).toLocaleDateString() : 'N/A'
         };
 
-        const earnedBadges = (profile.earnedBadges || []).sort((a, b) => new Date(a.earnedDate) - new Date(b.earnedDate));
+        const practiceCount = practices.length;
+        const earnedBadges = (profile.earnedBadges || []).map(badge => ({ ...badge, id: String(badge.id) }))
+          .sort((a, b) => new Date(a.earnedDate) - new Date(b.earnedDate));
         const latestBadges = earnedBadges.slice(-3).reverse();
-        const nextGoal = nextPhase ? nextPhase.goal : currentPhase.goal;
-        const progressPercent = Math.min(100, Math.max(0, Math.round((practices.length / nextGoal) * 100)));
-        const sessionsRemaining = Math.max(0, nextGoal - practices.length);
+
+        const milestoneBadges = ALL_BADGES
+          .filter(badge => typeof badge.milestone === 'number')
+          .sort((a, b) => a.milestone - b.milestone);
+
+        const nextMilestone = milestoneBadges.find(badge => badge.milestone > practiceCount) || null;
+        const previousMilestone = [...milestoneBadges]
+          .reverse()
+          .find(badge => badge.milestone <= practiceCount) || null;
+
+        const startMilestoneValue = previousMilestone ? previousMilestone.milestone : 0;
+        const targetMilestoneValue = nextMilestone ? nextMilestone.milestone : (previousMilestone ? previousMilestone.milestone : practiceCount || 1);
+        const milestoneDenominator = Math.max(1, targetMilestoneValue - startMilestoneValue);
+        const progressPercent = nextMilestone
+          ? Math.min(100, Math.max(0, Math.round(((practiceCount - startMilestoneValue) / milestoneDenominator) * 100)))
+          : 100;
+        const sessionsRemaining = nextMilestone ? Math.max(0, targetMilestoneValue - practiceCount) : 0;
         const sessionsLabel = sessionsRemaining === 1 ? 'session' : 'sessions';
+        const milestoneUnit = nextMilestone && nextMilestone.milestone === 1 ? 'practice' : 'practices';
+        const nextMilestoneLabel = nextMilestone
+          ? `${nextMilestone.milestone} ${milestoneUnit} · ${nextMilestone.name}`
+          : 'Veteran status — keep sharpening your edge.';
         const totalHours = (stats.totalTime / 60).toFixed(1);
         const lastPractice = practices.length ? practices[practices.length - 1] : null;
 
@@ -117,14 +129,14 @@
                     </div>
                     <span class="phase-chip">${stats.totalPractices} logged</span>
                   </div>
-                  <p class="panel-subtitle">Next milestone: ${nextPhase ? `${nextPhase.goal} practices · ${nextPhase.name}` : 'Mastery — keep sharpening your edge.'}</p>
+                  <p class="panel-subtitle">Next milestone: ${nextMilestoneLabel}</p>
                   <div class="progress-summary">
                     <div class="progress-ring" style="--progress:${progressPercent}%">
                       <span>${progressPercent}%</span>
                     </div>
                     <div class="progress-details">
-                      <p class="progress-count">${practices.length} / ${nextGoal} practices logged</p>
-                      <p class="progress-note">${sessionsRemaining > 0 ? `${sessionsRemaining} more ${sessionsLabel} until ${nextPhase ? nextPhase.name : currentPhase.name}.` : 'You hit this milestone. Stay humble and keep the reps coming.'}</p>
+                      <p class="progress-count">${practiceCount}${nextMilestone ? ` / ${nextMilestone.milestone}` : ''} practices logged</p>
+                      <p class="progress-note">${nextMilestone ? (sessionsRemaining > 0 ? `${sessionsRemaining} more ${sessionsLabel} until ${nextMilestone.name}.` : 'You hit this milestone. Stay humble and keep the reps coming.') : 'You carved out your own pace. Keep the story going.'}</p>
                       <p class="progress-last">${lastPractice ? `Last logged: ${new Date(lastPractice.date).toLocaleDateString()} · ${lastPractice.type}` : 'You have not logged a practice yet. Start today—no fluff, just work.'}</p>
                     </div>
                   </div>
@@ -171,7 +183,7 @@
                       const badgeInfo = ALL_BADGES.find(item => item.id === badge.id);
                       return `
                         <div class="badge-token">
-                          <span class="badge-icon">${BADGE_ICONS[badge.id] || '🥋'}</span>
+                          <span class="badge-icon">${badgeInfo ? badgeInfo.icon : '🥋'}</span>
                           <div class="badge-copy">
                             <p class="badge-name">${badgeInfo ? badgeInfo.name : 'Badge'}</p>
                             <p class="badge-meta">Practice #${badge.practiceNumber} · ${new Date(badge.earnedDate).toLocaleDateString()}</p>
@@ -306,20 +318,21 @@
                       <h2>Earned badges</h2>
                       <p class="panel-subtitle">Consistency over hype. Each badge marks a real milestone.</p>
                     </div>
-                    <span class="phase-chip subtle">${earnedBadges.length} / ${ALL_BADGES.length}</span>
                   </div>
-                  <div class="badge-grid">
-                    ${ALL_BADGES.map(badge => {
-                      const earned = earnedBadges.find(b => b.id === badge.id);
+                  <div class="badge-feed">
+                    ${earnedBadges.length ? earnedBadges.map(badge => {
+                      const badgeInfo = ALL_BADGES.find(item => item.id === badge.id);
                       return `
-                        <div class="badge-card ${earned ? 'earned' : ''}">
-                          <span class="badge-icon">${BADGE_ICONS[badge.id] || '🥋'}</span>
-                          <h3>${badge.name}</h3>
-                          <p class="badge-description">${badge.description}</p>
-                          ${earned ? `<p class="badge-earned">Unlocked ${new Date(earned.earnedDate).toLocaleDateString()} · Practice #${earned.practiceNumber}</p>` : '<p class="badge-earned">Keep grinding to unlock.</p>'}
+                        <div class="badge-card earned">
+                          <span class="badge-icon">${badgeInfo ? badgeInfo.icon : '🥋'}</span>
+                          <div class="badge-copy">
+                            <h3>${badgeInfo ? badgeInfo.name : 'Badge'}</h3>
+                            ${badgeInfo ? `<p class="badge-description">${badgeInfo.description}</p>` : ''}
+                            <p class="badge-earned">Earned ${new Date(badge.earnedDate).toLocaleDateString()} · Practice #${badge.practiceNumber}</p>
+                          </div>
                         </div>
                       `;
-                    }).join('')}
+                    }).join('') : '<p class="empty">Earned badges show up here. Keep logging.</p>'}
                   </div>
                 </article>
               </section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -480,31 +480,11 @@ input[type="range"]::-moz-range-thumb {
   border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
-.badge-icon {
-  font-size: 1.75rem;
-}
 
-.badge-copy {
+.badge-feed {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-}
-
-.badge-name {
-  margin: 0;
-  font-weight: 600;
-}
-
-.badge-meta {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.badge-grid {
-  display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .badge-card {
@@ -513,8 +493,9 @@ input[type="range"]::-moz-range-thumb {
   padding: 1.1rem;
   border: 1px solid rgba(148, 163, 184, 0.12);
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .badge-card.earned {
@@ -522,6 +503,22 @@ input[type="range"]::-moz-range-thumb {
   background: rgba(234, 88, 12, 0.18);
 }
 
+.badge-icon {
+  font-size: 2rem;
+}
+
+.badge-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.badge-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.badge-meta,
 .badge-description,
 .badge-earned {
   margin: 0;


### PR DESCRIPTION
## Summary
- expand the badge catalog with volume, consistency, hour, and phase milestones plus migration helpers
- compute badge unlocks from practice statistics so multiple awards surface together and metadata stays intact
- refresh the badge UI to only surface earned items and drive dashboard progress from milestone chunks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd7a45fffc83238fc99545e5f8c994